### PR TITLE
Improve copy button with Clipboard API

### DIFF
--- a/themes/Ghostfeed/layouts/partials/post_preview.html
+++ b/themes/Ghostfeed/layouts/partials/post_preview.html
@@ -45,14 +45,16 @@
         button.className = 'copy-button';
         button.textContent = 'Copy';
         button.addEventListener('click', () => {
-          const range = document.createRange();
-          range.selectNodeContents(block);
-          const selection = window.getSelection();
-          selection.removeAllRanges();
-          selection.addRange(range);
-          document.execCommand('copy');
-          button.textContent = 'Copied!';
-          setTimeout(() => { button.textContent = 'Copy'; }, 2000);
+          navigator.clipboard.writeText(block.textContent)
+            .then(() => {
+              button.textContent = 'Copied!';
+              setTimeout(() => { button.textContent = 'Copy'; }, 2000);
+            })
+            .catch(err => {
+              console.error('Copy failed', err);
+              button.textContent = 'Error';
+              setTimeout(() => { button.textContent = 'Copy'; }, 2000);
+            });
         });
         block.parentNode.insertBefore(button, block);
       });


### PR DESCRIPTION
## Summary
- update copy button logic to use `navigator.clipboard.writeText`
- handle copy success/error and remove unnecessary selection steps

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ca6961308325b48971f8a8b139d1